### PR TITLE
Fixing the optimizer not to push down invalid predicates

### DIFF
--- a/physical/optimizer/scenarios_test.go
+++ b/physical/optimizer/scenarios_test.go
@@ -540,6 +540,165 @@ func TestMergeDataSourceWithFilter(t *testing.T) {
 			},
 		},
 		{
+			name: "not mergable",
+			args: args{
+				plan: &physical.Filter{
+					Formula: physical.NewPredicate(
+						physical.NewFunctionExpression("test", []physical.Expression{physical.NewVariable("a.name")}),
+						physical.Equal,
+						physical.NewVariable("b.test"),
+					),
+					Source: &physical.DataSourceBuilder{
+						Executor:    nil,
+						PrimaryKeys: []octosql.VariableName{},
+						AvailableFilters: map[physical.FieldType]map[physical.Relation]struct{}{
+							physical.Primary: {
+								physical.Equal:    struct{}{},
+								physical.NotEqual: struct{}{},
+								physical.MoreThan: struct{}{},
+								physical.LessThan: struct{}{},
+							},
+							physical.Secondary: {
+								physical.Equal: struct{}{},
+							},
+						},
+						Filter: physical.NewConstant(true),
+						Alias:  "a",
+					},
+				},
+			},
+			want: &physical.Filter{
+				Formula: physical.NewPredicate(
+					physical.NewFunctionExpression("test", []physical.Expression{physical.NewVariable("a.name")}),
+					physical.Equal,
+					physical.NewVariable("b.test"),
+				),
+				Source: &physical.DataSourceBuilder{
+					Executor:    nil,
+					PrimaryKeys: []octosql.VariableName{},
+					AvailableFilters: map[physical.FieldType]map[physical.Relation]struct{}{
+						physical.Primary: {
+							physical.Equal:    struct{}{},
+							physical.NotEqual: struct{}{},
+							physical.MoreThan: struct{}{},
+							physical.LessThan: struct{}{},
+						},
+						physical.Secondary: {
+							physical.Equal: struct{}{},
+						},
+					},
+					Filter: physical.NewConstant(true),
+					Alias:  "a",
+				},
+			},
+		},
+		{
+			name: "not mergable",
+			args: args{
+				plan: &physical.Filter{
+					Formula: physical.NewPredicate(
+						physical.NewFunctionExpression("test", []physical.Expression{physical.NewVariable("a.name")}),
+						physical.Equal,
+						physical.NewVariable("a.test"),
+					),
+					Source: &physical.DataSourceBuilder{
+						Executor:    nil,
+						PrimaryKeys: []octosql.VariableName{},
+						AvailableFilters: map[physical.FieldType]map[physical.Relation]struct{}{
+							physical.Primary: {
+								physical.Equal:    struct{}{},
+								physical.NotEqual: struct{}{},
+								physical.MoreThan: struct{}{},
+								physical.LessThan: struct{}{},
+							},
+							physical.Secondary: {
+								physical.Equal: struct{}{},
+							},
+						},
+						Filter: physical.NewConstant(true),
+						Alias:  "a",
+					},
+				},
+			},
+			want: &physical.Filter{
+				Formula: physical.NewPredicate(
+					physical.NewFunctionExpression("test", []physical.Expression{physical.NewVariable("a.name")}),
+					physical.Equal,
+					physical.NewVariable("a.test"),
+				),
+				Source: &physical.DataSourceBuilder{
+					Executor:    nil,
+					PrimaryKeys: []octosql.VariableName{},
+					AvailableFilters: map[physical.FieldType]map[physical.Relation]struct{}{
+						physical.Primary: {
+							physical.Equal:    struct{}{},
+							physical.NotEqual: struct{}{},
+							physical.MoreThan: struct{}{},
+							physical.LessThan: struct{}{},
+						},
+						physical.Secondary: {
+							physical.Equal: struct{}{},
+						},
+					},
+					Filter: physical.NewConstant(true),
+					Alias:  "a",
+				},
+			},
+		},
+		{
+			name: "mergable",
+			args: args{
+				plan: &physical.Filter{
+					Formula: physical.NewPredicate(
+						physical.NewFunctionExpression("test", []physical.Expression{physical.NewVariable("b.name")}),
+						physical.Equal,
+						physical.NewVariable("a.test"),
+					),
+					Source: &physical.DataSourceBuilder{
+						Executor:    nil,
+						PrimaryKeys: []octosql.VariableName{},
+						AvailableFilters: map[physical.FieldType]map[physical.Relation]struct{}{
+							physical.Primary: {
+								physical.Equal:    struct{}{},
+								physical.NotEqual: struct{}{},
+								physical.MoreThan: struct{}{},
+								physical.LessThan: struct{}{},
+							},
+							physical.Secondary: {
+								physical.Equal: struct{}{},
+							},
+						},
+						Filter: physical.NewConstant(true),
+						Alias:  "a",
+					},
+				},
+			},
+			want: &physical.DataSourceBuilder{
+				Executor:    nil,
+				PrimaryKeys: []octosql.VariableName{},
+				AvailableFilters: map[physical.FieldType]map[physical.Relation]struct{}{
+					physical.Primary: {
+						physical.Equal:    struct{}{},
+						physical.NotEqual: struct{}{},
+						physical.MoreThan: struct{}{},
+						physical.LessThan: struct{}{},
+					},
+					physical.Secondary: {
+						physical.Equal: struct{}{},
+					},
+				},
+				Filter: physical.NewAnd(
+					physical.NewPredicate(
+						physical.NewFunctionExpression("test", []physical.Expression{physical.NewVariable("b.name")}),
+						physical.Equal,
+						physical.NewVariable("a.test"),
+					),
+					physical.NewConstant(true),
+				),
+				Alias: "a",
+			},
+		},
+		{
 			name: "simple partial merge",
 			args: args{
 				plan: &physical.Filter{


### PR DESCRIPTION
This fixes a bug where the optimizer can push down a predicate int(a.test) to the datasource a, which can't push down the whole int(a.test), so it makes a placeholder, which always is set to null, as the record isn't there.