### PR TITLE
Remove reduntant maps optimization

### DIFF
--- a/physical/optimizer/scenarios.go
+++ b/physical/optimizer/scenarios.go
@@ -12,11 +12,11 @@ import (
 
 var DefaultScenarios = []Scenario{
 	MergeRequalifiers,
-	RemoveEmptyMaps,
 	MergeFilters,
 	MergeDataSourceBuilderWithRequalifier,
 	MergeDataSourceBuilderWithFilter,
 	PushFilterBelowMap,
+	RemoveEmptyMaps,
 }
 
 var MergeRequalifiers = Scenario{
@@ -37,28 +37,6 @@ var MergeRequalifiers = Scenario{
 			Qualifier: match.Strings["qualifier"],
 			Source:    match.Nodes["source"],
 		}
-	},
-}
-
-var RemoveEmptyMaps = Scenario{
-	Name:        "remove empty maps",
-	Description: "Removes maps that have no expressions and keep set to true",
-	CandidateMatcher: &MapMatcher{
-		Keep:        &AnyPrimitiveMatcher{Name: "keep"},
-		Expressions: &AnyNamedExpressionListMatcher{Name: "expressions"},
-		Source:      &AnyNodeMatcher{Name: "source"},
-	},
-
-	CandidateApprover: func(match *Match) bool {
-		expressions := match.NamedExpressionLists["expressions"]
-		keep := match.Primitives["keep"]
-		keepCast := keep.(bool)
-
-		return len(expressions) == 0 && keepCast
-	},
-
-	Reassembler: func(match *Match) physical.Node {
-		return match.Nodes["source"]
 	},
 }
 
@@ -376,5 +354,27 @@ var PushFilterBelowMap = Scenario{
 		}
 
 		return out
+	},
+}
+
+var RemoveEmptyMaps = Scenario{
+	Name:        "remove empty maps",
+	Description: "Removes maps that have no expressions and keep set to true",
+	CandidateMatcher: &MapMatcher{
+		Keep:        &AnyPrimitiveMatcher{Name: "keep"},
+		Expressions: &AnyNamedExpressionListMatcher{Name: "expressions"},
+		Source:      &AnyNodeMatcher{Name: "source"},
+	},
+
+	CandidateApprover: func(match *Match) bool {
+		expressions := match.NamedExpressionLists["expressions"]
+		keep := match.Primitives["keep"]
+		keepCast := keep.(bool)
+
+		return len(expressions) == 0 && keepCast
+	},
+
+	Reassembler: func(match *Match) physical.Node {
+		return match.Nodes["source"]
 	},
 }

--- a/physical/optimizer/scenarios.go
+++ b/physical/optimizer/scenarios.go
@@ -11,6 +11,7 @@ import (
 
 var DefaultScenarios = []Scenario{
 	MergeRequalifiers,
+	RemoveEmptyMaps,
 	MergeFilters,
 	MergeDataSourceBuilderWithRequalifier,
 	MergeDataSourceBuilderWithFilter,
@@ -35,6 +36,31 @@ var MergeRequalifiers = Scenario{
 			Qualifier: match.Strings["qualifier"],
 			Source:    match.Nodes["source"],
 		}
+	},
+}
+
+var RemoveEmptyMaps = Scenario{
+	Name:        "remove empty maps",
+	Description: "Removes maps that have no expressions and keep set to true",
+	CandidateMatcher: &MapMatcher{
+		Keep:        &AnyPrimitiveMatcher{Name: "keep"},
+		Expressions: &AnyNamedExpressionListMatcher{Name: "expressions"},
+		Source:      &AnyNodeMatcher{Name: "source"},
+	},
+
+	CandidateApprover: func(match *Match) bool {
+		expressions := match.NamedExpressionLists["expressions"]
+		keep := match.Primitives["keep"]
+		keepCast, ok := keep.(bool)
+		if !ok {
+			return false
+		}
+
+		return len(expressions) == 0 && keepCast
+	},
+
+	Reassembler: func(match *Match) physical.Node {
+		return match.Nodes["source"]
 	},
 }
 

--- a/physical/optimizer/scenarios.go
+++ b/physical/optimizer/scenarios.go
@@ -52,10 +52,7 @@ var RemoveEmptyMaps = Scenario{
 	CandidateApprover: func(match *Match) bool {
 		expressions := match.NamedExpressionLists["expressions"]
 		keep := match.Primitives["keep"]
-		keepCast, ok := keep.(bool)
-		if !ok {
-			return false
-		}
+		keepCast := keep.(bool)
 
 		return len(expressions) == 0 && keepCast
 	},

--- a/physical/optimizer/scenarios_test.go
+++ b/physical/optimizer/scenarios_test.go
@@ -9,6 +9,67 @@ import (
 	"github.com/cube2222/octosql/physical"
 )
 
+func TestRemoveEmptyMaps(t *testing.T) {
+	type args struct {
+		plan physical.Node
+	}
+	tests := []struct {
+		name string
+		args args
+		want physical.Node
+	}{
+		{
+			name: "no match - existing expressions",
+			args: args{
+				physical.NewMap(
+					[]physical.NamedExpression{physical.NewVariable("age")},
+					&PlaceholderNode{Name: "stub"},
+					false,
+				),
+			},
+			want: physical.NewMap(
+				[]physical.NamedExpression{physical.NewVariable("age")},
+				&PlaceholderNode{Name: "stub"},
+				false,
+			),
+		},
+		{
+			name: "no match - no expressions, keep is false",
+			args: args{
+				physical.NewMap(
+					[]physical.NamedExpression{},
+					&PlaceholderNode{Name: "stub"},
+					false,
+				),
+			},
+			want: physical.NewMap(
+				[]physical.NamedExpression{},
+				&PlaceholderNode{Name: "stub"},
+				false,
+			),
+		},
+		{
+			name: "match - no expressions, keep is true",
+			args: args{
+				physical.NewMap(
+					[]physical.NamedExpression{},
+					&PlaceholderNode{Name: "stub"},
+					true,
+				),
+			},
+			want: &PlaceholderNode{Name: "stub"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Optimize(context.Background(), []Scenario{RemoveEmptyMaps}, tt.args.plan); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RemoveEmptyMaps() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMergeRequalifiers(t *testing.T) {
 	type args struct {
 		plan physical.Node
@@ -710,42 +771,45 @@ func TestMultiOptimization(t *testing.T) {
 			name: "multiple optimizations",
 			args: args{
 				plan: &physical.Map{
-					Expressions: []physical.NamedExpression{physical.NewVariable("expr")},
-					Source: &physical.Requalifier{
-						Qualifier: "a",
+					Expressions: []physical.NamedExpression{},
+					Source: &physical.Map{
+						Expressions: []physical.NamedExpression{physical.NewVariable("expr")},
 						Source: &physical.Requalifier{
-							Qualifier: "b",
-							Source: &physical.Filter{
-								Formula: physical.NewConstant(true),
+							Qualifier: "a",
+							Source: &physical.Requalifier{
+								Qualifier: "b",
 								Source: &physical.Filter{
-									Formula: physical.NewConstant(false),
+									Formula: physical.NewConstant(true),
 									Source: &physical.Filter{
-										Formula: physical.NewConstant(true),
-										Source: &physical.Requalifier{
-											Qualifier: "a",
+										Formula: physical.NewConstant(false),
+										Source: &physical.Filter{
+											Formula: physical.NewConstant(true),
 											Source: &physical.Requalifier{
-												Qualifier: "b",
-												Source: &physical.DataSourceBuilder{
-													Materializer: nil,
-													PrimaryKeys:  []octosql.VariableName{octosql.NewVariableName("a")},
-													AvailableFilters: map[physical.FieldType]map[physical.Relation]struct{}{
-														physical.Primary: {
-															physical.Equal:    struct{}{},
-															physical.NotEqual: struct{}{},
+												Qualifier: "a",
+												Source: &physical.Requalifier{
+													Qualifier: "b",
+													Source: &physical.DataSourceBuilder{
+														Materializer: nil,
+														PrimaryKeys:  []octosql.VariableName{octosql.NewVariableName("a")},
+														AvailableFilters: map[physical.FieldType]map[physical.Relation]struct{}{
+															physical.Primary: {
+																physical.Equal:    struct{}{},
+																physical.NotEqual: struct{}{},
+															},
+															physical.Secondary: {
+																physical.Equal:    struct{}{},
+																physical.NotEqual: struct{}{},
+																physical.MoreThan: struct{}{},
+																physical.LessThan: struct{}{},
+															},
 														},
-														physical.Secondary: {
-															physical.Equal:    struct{}{},
-															physical.NotEqual: struct{}{},
-															physical.MoreThan: struct{}{},
-															physical.LessThan: struct{}{},
-														},
+														Filter: physical.NewAnd(
+															physical.NewConstant(true),
+															physical.NewConstant(false),
+														),
+														Name:  "baz",
+														Alias: "c",
 													},
-													Filter: physical.NewAnd(
-														physical.NewConstant(true),
-														physical.NewConstant(false),
-													),
-													Name:  "baz",
-													Alias: "c",
 												},
 											},
 										},
@@ -754,6 +818,7 @@ func TestMultiOptimization(t *testing.T) {
 							},
 						},
 					},
+					Keep: true,
 				},
 			},
 			want: &physical.Map{
@@ -803,6 +868,7 @@ func TestMultiOptimization(t *testing.T) {
 					MergeRequalifiers,
 					MergeFilters,
 					MergeDataSourceBuilderWithRequalifier,
+					RemoveEmptyMaps,
 				},
 				tt.args.plan,
 			); !reflect.DeepEqual(got, tt.want) {


### PR DESCRIPTION
This PR introduces a optimization scenario that reduces
Map{expressions: [], source: some_source, keep: true}
to
some_source,
since those two nodes yield the same results.