### PR TITLE
fix: setting a unique location for the configuration folder

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,13 +13,17 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var octosqlHomeDir = func() string {
+var homeDir = func() string {
 	dir, err := homedir.Dir()
 	if err != nil {
 		log.Fatalf("couldn't get user home directory: %s", err)
 	}
-	return filepath.Join(dir, ".octosql")
+	return dir
 }()
+
+func OctoSQLHomeDir() string {
+	return filepath.Join(homeDir, ".octosql")
+}
 
 type Config struct {
 	Databases []DatabaseConfig `yaml:"databases"`
@@ -33,7 +37,7 @@ type DatabaseConfig struct {
 }
 
 func Read() (*Config, error) {
-	data, err := ioutil.ReadFile(filepath.Join(octosqlHomeDir, "octosql.yml"))
+	data, err := ioutil.ReadFile(filepath.Join(OctoSQLHomeDir(), "octosql.yml"))
 	if err != nil {
 		if os.IsNotExist(err) {
 			return &Config{

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -5,20 +5,14 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/mitchellh/go-homedir"
+	"github.com/cube2222/octosql/config"
 )
 
 var Output *os.File
 
 func init() {
-	dir, err := homedir.Dir()
-	if err != nil {
-		log.Fatalf("couldn't get user home directory: %s", err)
-	}
-	if err := os.MkdirAll(filepath.Join(dir, ".octosql"), 0755); err != nil {
-		log.Fatalf("couldn't create ~/.octosql home directory: %s", err)
-	}
-	path := filepath.Join(dir, ".octosql/logs.txt")
+	dir := config.OctoSQLHomeDir()
+	path := filepath.Join(dir, "logs.txt")
 	f, err := os.Create(path)
 	if err != nil {
 		log.Fatalf("couldn't create logs file: %s", err)

--- a/plugins/executor/executor.go
+++ b/plugins/executor/executor.go
@@ -37,8 +37,8 @@ type PluginExecutor struct {
 	done           []chan error
 }
 
-func (e *PluginExecutor) RunPlugin(ctx context.Context, pluginRef config.PluginReference, databaseName string, version *semver.Version, config yaml.Node) (*Database, error) {
-	tmpRootDir := "/Users/jakub/.octosql/tmp/plugins"
+func (e *PluginExecutor) RunPlugin(ctx context.Context, pluginRef config.PluginReference, databaseName string, version *semver.Version, dbConfig yaml.Node) (*Database, error) {
+	tmpRootDir := filepath.Join(config.OctoSQLHomeDir(), "tmp/plugins")
 	if err := os.MkdirAll(tmpRootDir, os.ModePerm); err != nil {
 		return nil, fmt.Errorf("couldn't create tmp directory %s: %w", tmpRootDir, err)
 	}
@@ -55,7 +55,7 @@ func (e *PluginExecutor) RunPlugin(ctx context.Context, pluginRef config.PluginR
 	}
 
 	input, err := json.Marshal(&plugins.PluginInput{
-		Config: config,
+		Config: dbConfig,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("couldn't encode plugin input to JSON: %w", err)

--- a/plugins/manager/manager.go
+++ b/plugins/manager/manager.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/mholt/archiver"
-	"github.com/mitchellh/go-homedir"
 
 	"github.com/cube2222/octosql/config"
 	"github.com/cube2222/octosql/plugins/repository"
@@ -107,11 +106,8 @@ func getPluginDir() string {
 		return out
 	}
 
-	dir, err := homedir.Dir()
-	if err != nil {
-		log.Fatalf("couldn't get user home directory: %s", err)
-	}
-	return filepath.Join(dir, ".octosql/plugins")
+	dir := config.OctoSQLHomeDir()
+	return filepath.Join(dir, "plugins")
 }
 
 func (m *PluginManager) Install(ctx context.Context, name string, constraint *semver.Constraints) error {

--- a/plugins/repository/repository.go
+++ b/plugins/repository/repository.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,15 +13,12 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver"
-	"github.com/mitchellh/go-homedir"
+	"github.com/cube2222/octosql/config"
 )
 
 var repositoriesDir = func() string {
-	dir, err := homedir.Dir()
-	if err != nil {
-		log.Fatalf("couldn't get user home directory: %s", err)
-	}
-	return filepath.Join(dir, ".octosql/repositories")
+	dir := config.OctoSQLHomeDir()
+	return filepath.Join(dir, "repositories")
 }()
 
 var officialPluginRepositoryURL = func() string {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -13,16 +13,13 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/mitchellh/go-homedir"
+	"github.com/cube2222/octosql/config"
 	"github.com/oklog/ulid/v2"
 )
 
 var telemetryDir = func() string {
-	dir, err := homedir.Dir()
-	if err != nil {
-		log.Fatalf("couldn't get user home directory: %s", err)
-	}
-	return filepath.Join(dir, ".octosql/telemetry")
+	dir := config.OctoSQLHomeDir()
+	return filepath.Join(dir, "telemetry")
 }()
 
 type event struct {


### PR DESCRIPTION
Simple change, but brings inconvenience when installing for the first time.
Issue cited: https://github.com/cube2222/octosql/issues/265