### PR TITLE
Switch $HOME/.octosql to XDG Spec

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -10,9 +10,12 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver"
+	"github.com/adrg/xdg"
 	"github.com/mitchellh/go-homedir"
 	"gopkg.in/yaml.v3"
 )
+
+const ApplicationName = "octosql"
 
 var octosqlHomeDir = func() string {
 	dir, err := homedir.Dir()
@@ -20,6 +23,30 @@ var octosqlHomeDir = func() string {
 		log.Fatalf("couldn't get user home directory: %s", err)
 	}
 	return filepath.Join(dir, ".octosql")
+}()
+
+var OctosqlConfigDir = func() string {
+	configDirPath, err := xdg.SearchConfigFile(ApplicationName)
+	if err != nil {
+		return octosqlHomeDir
+	}
+	return configDirPath
+}()
+
+var OctosqlCacheDir = func() string {
+	cacheDirPath, err := xdg.SearchCacheFile(ApplicationName)
+	if err != nil {
+		return octosqlHomeDir
+	}
+	return cacheDirPath
+}()
+
+var OctosqlDataDir = func() string {
+	dataDirPath, err := xdg.SearchDataFile(ApplicationName)
+	if err != nil {
+		return octosqlHomeDir
+	}
+	return dataDirPath
 }()
 
 type Config struct {
@@ -45,7 +72,7 @@ type JSONConfig struct {
 
 func Read() (*Config, error) {
 	var config Config
-	data, err := ioutil.ReadFile(filepath.Join(octosqlHomeDir, "octosql.yml"))
+	data, err := ioutil.ReadFile(filepath.Join(OctosqlConfigDir, "octosql.yml"))
 	if err != nil && os.IsNotExist(err) {
 		config = Config{}
 	} else if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 )
 
 require (
+	github.com/adrg/xdg v0.4.0 // indirect
 	github.com/andybalholm/brotli v1.0.3 // indirect
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cockroachdb/apd v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3Q
 github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/adrg/xdg v0.4.0 h1:RzRqFcjH4nE5C6oTAxhBtoE2IRyjBSa62SCbyPidvls=
+github.com/adrg/xdg v0.4.0/go.mod h1:N6ag73EX4wyxeaoeHctc1mas01KZgsj5tYiAIwqJE/E=
 github.com/andybalholm/brotli v1.0.3 h1:fpcw+r1N1h0Poc1F/pHbW40cUm/lMEQslZtCkBQ0UnM=
 github.com/andybalholm/brotli v1.0.3/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -232,6 +234,7 @@ golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211110154304-99a53858aa08/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/logs/logs.go
+++ b/logs/logs.go
@@ -5,20 +5,13 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/mitchellh/go-homedir"
+	"github.com/cube2222/octosql/config"
 )
 
 var Output *os.File
 
 func InitializeFileLogger() {
-	dir, err := homedir.Dir()
-	if err != nil {
-		log.Fatalf("couldn't get user home directory: %s", err)
-	}
-	if err := os.MkdirAll(filepath.Join(dir, ".octosql"), 0755); err != nil {
-		log.Fatalf("couldn't create ~/.octosql home directory: %s", err)
-	}
-	path := filepath.Join(dir, ".octosql/logs.txt")
+	path := filepath.Join(config.OctosqlCacheDir, "logs.txt")
 	f, err := os.Create(path)
 	if err != nil {
 		log.Fatalf("couldn't create logs file: %s", err)

--- a/plugins/executor/executor.go
+++ b/plugins/executor/executor.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"os"
 	"os/exec"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/kr/text"
-	"github.com/mitchellh/go-homedir"
 	"google.golang.org/grpc"
 	"gopkg.in/yaml.v3"
 
@@ -30,11 +28,8 @@ var tmpPluginsDir = func() string {
 	if value, ok := os.LookupEnv("OCTOSQL_PLUGIN_TMP_DIR"); ok {
 		return value
 	}
-	dir, err := homedir.Dir()
-	if err != nil {
-		log.Fatalf("couldn't get user home directory: %s", err)
-	}
-	return filepath.Join(dir, ".octosql/tmp/plugins")
+
+	return filepath.Join(config.OctosqlCacheDir, "tmp", "plugins")
 }()
 
 type Manager interface {

--- a/plugins/manager/extensions.go
+++ b/plugins/manager/extensions.go
@@ -7,15 +7,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/mitchellh/go-homedir"
+	"github.com/cube2222/octosql/config"
 )
 
 var octosqlFileExtensionHandlersFile = func() string {
-	dir, err := homedir.Dir()
-	if err != nil {
-		log.Fatalf("couldn't get user home directory: %s", err)
-	}
-	return filepath.Join(dir, ".octosql/file_extension_handlers.json")
+	return filepath.Join(config.OctosqlConfigDir, "file_extension_handlers.json")
 }()
 
 func (*PluginManager) GetFileExtensionHandlers() (map[string]string, error) {

--- a/plugins/manager/manager.go
+++ b/plugins/manager/manager.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/mholt/archiver"
-	"github.com/mitchellh/go-homedir"
 
 	"github.com/cube2222/octosql/config"
 	"github.com/cube2222/octosql/plugins/repository"
@@ -107,11 +106,7 @@ func getPluginDir() string {
 		return out
 	}
 
-	dir, err := homedir.Dir()
-	if err != nil {
-		log.Fatalf("couldn't get user home directory: %s", err)
-	}
-	return filepath.Join(dir, ".octosql/plugins")
+	return filepath.Join(config.OctosqlDataDir, "plugins")
 }
 
 func (m *PluginManager) Install(ctx context.Context, name string, constraint *semver.Constraints) error {

--- a/plugins/repository/repository.go
+++ b/plugins/repository/repository.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -14,15 +13,11 @@ import (
 	"strings"
 
 	"github.com/Masterminds/semver"
-	"github.com/mitchellh/go-homedir"
+	"github.com/cube2222/octosql/config"
 )
 
 var repositoriesDir = func() string {
-	dir, err := homedir.Dir()
-	if err != nil {
-		log.Fatalf("couldn't get user home directory: %s", err)
-	}
-	return filepath.Join(dir, ".octosql/repositories")
+	return filepath.Join(config.OctosqlDataDir, "repositories")
 }()
 
 var officialPluginRepositoryURL = func() string {

--- a/telemetry/telemetry.go
+++ b/telemetry/telemetry.go
@@ -13,16 +13,12 @@ import (
 	"runtime"
 	"time"
 
-	"github.com/mitchellh/go-homedir"
+	"github.com/cube2222/octosql/config"
 	"github.com/oklog/ulid/v2"
 )
 
 var telemetryDir = func() string {
-	dir, err := homedir.Dir()
-	if err != nil {
-		log.Fatalf("couldn't get user home directory: %s", err)
-	}
-	return filepath.Join(dir, ".octosql/telemetry")
+	return filepath.Join(config.OctosqlCacheDir, ".octosql/telemetry")
 }()
 
 type event struct {


### PR DESCRIPTION
Change default configs/plugins/repos/logs location according to XDG Specification.

App will look for:
- the config file in `$XDG_CONFIG_HOME/octosql/octosql.yml` with fallback to current `$HOME/.octosql/octosql.yml`
- the logs file in `$XDG_CACHE_HOME/octosql/logs.txt` with fallback to current `$HOME/.octosql/logs.txt`
- the plugins tmp dir in `$XDG_CACHE_HOME/octosql/tmp/plugins/` with fallback to current `$HOME/.octosql/tmp/plugins/`
- the extension_handlers file in `$XDG_CONFIG_HOME/octosql/file_extension_handlers.json` with fallback to current `$HOME/.octosql/file_extension_handlers.json`
- the plugins dir in `$XDG_DATA_HOME/octosql/plugins` with fallback to current `$HOME/.octosql/plugins`
- the repositories dir in `$XDG_DATA_HOME/octosql/repositories` with fallback to current `$HOME/.octosql/repositories`