### PR TITLE
fix: fix miss makezero bug

### DIFF
--- a/outputs/stream/internally_consistent_output_stream_wrapper.go
+++ b/outputs/stream/internally_consistent_output_stream_wrapper.go
@@ -23,7 +23,7 @@ func (node *InternallyConsistentOutputStreamWrapper) Run(ctx ExecutionContext, p
 				afterWatermarkCount++
 			}
 		}
-		newPending := make([]Record, afterWatermarkCount)
+		newPending := make([]Record, 0, afterWatermarkCount)
 		for i := range pending {
 			if pending[i].EventTime.After(watermark) {
 				newPending = append(newPending, pending[i])


### PR DESCRIPTION
I was running github actions to run linter [makezero](https://github.com/ashanbrown/makezero) for top github golang repos.

see issues https://github.com/alingse/go-linter-runner/issues/1

and the github actions output https://github.com/alingse/go-linter-runner/actions/runs/9242658341/job/25425755939

```
====================================================================================================
append to slice `newPending` with non-zero initialized length at https://github.com/cube2222/octosql/blob/main/outputs/stream/internally_consistent_output_stream_wrapper.go#L2[9](https://github.com/alingse/go-linter-runner/actions/runs/9242658341/job/25425755939#step:4:10):18
====================================================================================================
```

but the `newPending` `pending` convert  is complex to understand, maybe this was a feature ?